### PR TITLE
feat: hide navbar on hero section in desktop mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1250,9 +1250,22 @@
                     link.classList.add('active');
                 }
             });
+
+            const navbar = document.querySelector('.navbar');
+            if (window.innerWidth > 768) {
+                if (current === 'home') {
+                    navbar.classList.add('navbar-hidden');
+                } else {
+                    navbar.classList.remove('navbar-hidden');
+                }
+            } else {
+                navbar.classList.remove('navbar-hidden');
+            }
         }
 
         window.addEventListener('scroll', updateActiveNavLink);
+        window.addEventListener('resize', updateActiveNavLink);
+        document.addEventListener('DOMContentLoaded', updateActiveNavLink);
 
         // Project Tabs
         const projectTabs = document.querySelectorAll('.project-tab');

--- a/styles.css
+++ b/styles.css
@@ -389,6 +389,12 @@ main {
   transform: translateX(-50%) translateY(-2px);
 }
 
+.navbar-hidden {
+  opacity: 0;
+  transform: translateX(-50%) translateY(-100%);
+  pointer-events: none;
+}
+
 .nav-container {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Hide the navbar over the hero section on desktop to keep the focus on the page intro. The navbar stays visible on mobile and reappears when you leave the hero.

- **New Features**
  - On desktop (>768px), the navbar is hidden on the home/hero section and shown on other sections; always visible on mobile.
  - Added a navbar-hidden style (opacity 0, translate up, no pointer events) and JS to toggle it on scroll, resize, and DOM load.

<!-- End of auto-generated description by cubic. -->

