### PR TITLE
Fix: Make AI section cards mobile friendly

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5024,6 +5024,10 @@ section {
         grid-template-columns: 1fr;
         gap: 2rem;
     }
+
+    #ai-panel .ai-showcase-content {
+        grid-template-columns: 1fr;
+    }
     
     .ai-showcase-right {
         order: -1;


### PR DESCRIPTION
The AI section cards were not responsive on mobile devices due to a CSS rule that set a fixed-width column.

This change adds a new CSS rule within the existing media query to make the AI section cards stack vertically on smaller screens, matching the behavior of the other project cards.

This resolves the mobile responsiveness issue without affecting the desktop view.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes mobile responsiveness of the AI section cards. Adds a mobile breakpoint rule to stack the cards in one column, matching other project cards and leaving desktop unchanged.

<!-- End of auto-generated description by cubic. -->

