### PR TITLE
Fix: Center social links in mobile view

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -894,6 +894,10 @@ main {
     justify-content: center;
   }
 
+  .hero-social-links {
+    justify-content: center;
+  }
+
   .modern-hero-grid {
     grid-template-columns: repeat(2, 1fr);
     grid-template-rows: repeat(5, 1fr);


### PR DESCRIPTION
The social media icons in the hero section were not centered on mobile devices. This commit adds the necessary CSS to center them.