### PR TITLE
feat: implement scroll-triggered fade-in animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
     </section>
 
         <!-- About Section -->
-        <section id="about" class="about">
+        <section id="about" class="about fade-in-section">
             <div class="container">
                 <header class="section-header">
                     <span class="section-number" aria-hidden="true">01</span>
@@ -348,7 +348,7 @@
         </section>
 
         <!-- Projects Section -->
-        <section id="projects" class="projects">
+        <section id="projects" class="projects fade-in-section">
             <div class="container">
                 <header class="section-header">
                     <span class="section-number" aria-hidden="true">02</span>
@@ -1004,7 +1004,7 @@
         </section>
 
         <!-- Blog Section -->
-        <section id="blog" class="blog">
+        <section id="blog" class="blog fade-in-section">
             <div class="container">
                 <header class="section-header">
                     <span class="section-number" aria-hidden="true">03</span>
@@ -1025,7 +1025,7 @@
         </section>
 
         <!-- Contact Section -->
-        <section id="contact" class="contact">
+        <section id="contact" class="contact fade-in-section">
             <div class="container">
                 <header class="section-header">
                     <span class="section-number" aria-hidden="true">03</span>
@@ -1209,16 +1209,17 @@
             rootMargin: '0px 0px -50px 0px'
         };
 
-        const observer = new IntersectionObserver((entries) => {
+        const observer = new IntersectionObserver((entries, observer) => {
             entries.forEach(entry => {
                 if (entry.isIntersecting) {
-                    entry.target.classList.add('animate-in');
+                    entry.target.classList.add('is-visible');
+                    observer.unobserve(entry.target);
                 }
             });
         }, observerOptions);
 
         // Observe elements for animation
-        document.querySelectorAll('.skills-card, .education-card, .masonry-item, .section-header, .quick-card').forEach(el => {
+        document.querySelectorAll('.fade-in-section').forEach(el => {
             observer.observe(el);
         });
 

--- a/styles.css
+++ b/styles.css
@@ -1589,6 +1589,18 @@ main {
   animation: fadeInUp 0.6s ease forwards;
 }
 
+/* Scroll-triggered fade-in animation */
+.fade-in-section {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.fade-in-section.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 /* ==========================================================================
    COMMON STYLES
    ========================================================================== */


### PR DESCRIPTION
This commit introduces a smooth, scroll-triggered fade-in animation for the main sections of the portfolio website (About, Projects, Blog, and Contact).

The implementation uses the Intersection Observer API to efficiently detect when a section enters the viewport. When a section is visible, a CSS class is added to trigger a fade-in and slide-up animation.

The "Skills" part of the website is included within the "About" section, so it fades in along with the rest of the "About" content. The "Blog" section was also included in the animation as it is a major section in the site's navigation.