### PR TITLE
refactor: apply fade-in animation to project cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@
         </section>
 
         <!-- Projects Section -->
-        <section id="projects" class="projects fade-in-section">
+        <section id="projects" class="projects">
             <div class="container">
                 <header class="section-header">
                     <span class="section-number" aria-hidden="true">02</span>
@@ -391,7 +391,7 @@
 
                     <div class="ai-showcase-grid">
                         <!-- Featured Project 1: CodeCraft AI -->
-                        <article class="ai-showcase-card">
+                        <article class="ai-showcase-card fade-in-section">
                             <a href="https://github.com/akshaykarthicks/CodeCraft-AI.git" target="_blank"
                                 rel="noopener noreferrer" class="ai-showcase-content"
                                 style="text-decoration:none; color:inherit;">
@@ -437,7 +437,7 @@
                         </article>
 
                         <!-- Featured Project 2: Taskly AI -->
-                        <article class="ai-showcase-card">
+                        <article class="ai-showcase-card fade-in-section">
                             <a href="https://taskly-ai-five.vercel.app/" target="_blank" rel="noopener noreferrer"
                                 class="ai-showcase-content" style="text-decoration:none; color:inherit;">
                                 <div class="ai-showcase-left">
@@ -482,7 +482,7 @@
                         </article>
 
                         <!-- Featured Project 3: ForgeNest -->
-                        <article class="ai-showcase-card">
+                        <article class="ai-showcase-card fade-in-section">
                             <a href="https://forgenest.vercel.app/" target="_blank" rel="noopener noreferrer"
                                 class="ai-showcase-content" style="text-decoration:none; color:inherit;">
                                 <div class="ai-showcase-left">
@@ -525,7 +525,7 @@
                         </article>
 
                         <!-- Featured Project 4: Jarvis AI -->
-                        <article class="ai-showcase-card">
+                        <article class="ai-showcase-card fade-in-section">
                             <a href="https://github.com/akshaykarthicks/Jarvis_Agent" target="_blank"
                                 rel="noopener noreferrer" class="ai-showcase-content"
                                 style="text-decoration:none; color:inherit;">
@@ -568,7 +568,7 @@
                         </article>
 
                         <!-- Featured Project 5: PromptHub -->
-                        <article class="ai-showcase-card">
+                        <article class="ai-showcase-card fade-in-section">
                             <a href="https://prompthub-umber.vercel.app/" target="_blank" rel="noopener noreferrer"
                                 class="ai-showcase-content" style="text-decoration:none; color:inherit;">
                                 <div class="ai-showcase-left">
@@ -610,7 +610,7 @@
                         </article>
 
                         <!-- Featured Project 6: ReflectSpace -->
-                        <article class="ai-showcase-card">
+                        <article class="ai-showcase-card fade-in-section">
                             <a href="https://reflectspace.vercel.app/" target="_blank" rel="noopener noreferrer"
                                 class="ai-showcase-content" style="text-decoration:none; color:inherit;">
                                 <div class="ai-showcase-left">
@@ -651,7 +651,7 @@
                         </article>
 
                         <!-- Featured Project 7: Time Capsule -->
-                        <article class="ai-showcase-card">
+                        <article class="ai-showcase-card fade-in-section">
                             <a href="https://time-capsule-xjtz.onrender.com" target="_blank" rel="noopener noreferrer"
                                 class="ai-showcase-content" style="text-decoration:none; color:inherit;">
                                 <div class="ai-showcase-left">
@@ -710,7 +710,7 @@
                 </div>
                 <div class="ai-showcase-grid">
                     <!-- AI Project 1: Crew AI Agents -->
-                    <article class="ai-showcase-card">
+                    <article class="ai-showcase-card fade-in-section">
                         <a href="https://github.com/stars/akshaykarthicks/lists/crewai-agents" target="_blank"
                             rel="noopener noreferrer" class="ai-showcase-content"
                             style="text-decoration:none; color:inherit;">
@@ -752,7 +752,7 @@
                     </article>
 
                     <!-- AI Project 2: N8N Agents -->
-                    <article class="ai-showcase-card">
+                    <article class="ai-showcase-card fade-in-section">
                         <a href="https://github.com/stars/akshaykarthicks/lists/n8n" target="_blank"
                             rel="noopener noreferrer" class="ai-showcase-content"
                             style="text-decoration:none; color:inherit;">
@@ -793,7 +793,7 @@
                     </article>
 
                     <!-- AI Project 3: Web Sharing -->
-                    <article class="ai-showcase-card">
+                    <article class="ai-showcase-card fade-in-section">
                         <a href="https://sleek-transfer-web.lovable.app/" target="_blank" rel="noopener noreferrer"
                             class="ai-showcase-content" style="text-decoration:none; color:inherit;">
                             <div class="ai-showcase-left">
@@ -835,7 +835,7 @@
             </div>
 
 
-            <article class="ai-showcase-card hidden">
+            <article class="ai-showcase-card hidden fade-in-section">
                 <div class="ai-showcase-content">
                     <div class="ai-showcase-left">
                         <div class="ai-showcase-header">
@@ -932,7 +932,7 @@
                         <h3 class="quick-title">Quick Projects</h3>
                         <div class="quick-grid">
                             <a href="https://myblog-xwlx.onrender.com" target="_blank" rel="noopener noreferrer"
-                                class="quick-card">
+                                class="quick-card fade-in-section">
                                 <div class="quick-icon">
                                     <i class="fas fa-blog" aria-hidden="true"></i>
                                 </div>
@@ -943,7 +943,7 @@
                             </a>
 
                             <a href="https://our-ecom.onrender.com/" target="_blank" rel="noopener noreferrer"
-                                class="quick-card">
+                                class="quick-card fade-in-section">
                                 <div class="quick-icon">
                                     <i class="fas fa-shopping-cart" aria-hidden="true"></i>
                                 </div>
@@ -954,7 +954,7 @@
                             </a>
 
                             <a href="https://github.com/akshaykarthicks/Weather-App.git" target="_blank"
-                                rel="noopener noreferrer" class="quick-card">
+                                rel="noopener noreferrer" class="quick-card fade-in-section">
                                 <div class="quick-icon">
                                     <i class="fas fa-cloud-sun" aria-hidden="true"></i>
                                 </div>
@@ -965,7 +965,7 @@
                             </a>
 
                             <a href="https://akshaykarthicks.github.io/Music_lyrics_api/" target="_blank"
-                                rel="noopener noreferrer" class="quick-card">
+                                rel="noopener noreferrer" class="quick-card fade-in-section">
                                 <div class="quick-icon">
                                     <i class="fas fa-music" aria-hidden="true"></i>
                                 </div>
@@ -976,7 +976,7 @@
                             </a>
 
                             <a href="https://github.com/akshaykarthicks/RESUMEPARSER---NLP.git" target="_blank"
-                                rel="noopener noreferrer" class="quick-card">
+                                rel="noopener noreferrer" class="quick-card fade-in-section">
                                 <div class="quick-icon">
                                     <i class="fas fa-file-alt" aria-hidden="true"></i>
                                 </div>
@@ -987,7 +987,7 @@
                             </a>
 
                             <a href="https://our-social.onrender.com" target="_blank" rel="noopener noreferrer"
-                                class="quick-card">
+                                class="quick-card fade-in-section">
                                 <div class="quick-icon">
                                     <i class="fas fa-users" aria-hidden="true"></i>
                                 </div>
@@ -1219,7 +1219,7 @@
         }, observerOptions);
 
         // Observe elements for animation
-        document.querySelectorAll('.fade-in-section').forEach(el => {
+        document.querySelectorAll('.fade-in-section, .ai-showcase-card, .quick-card').forEach(el => {
             observer.observe(el);
         });
 


### PR DESCRIPTION
This commit refactors the scroll-triggered fade-in animation to be more granular. Instead of fading in the entire "Projects" section at once, the animation is now applied to individual project cards within the section.

This change improves the user experience by revealing content more progressively as the user scrolls. The `IntersectionObserver` now targets `.ai-showcase-card` and `.quick-card` elements, applying the fade-in effect to each card as it enters the viewport.