### PR TITLE
feat: Add subtle dot-grid background to content sections

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1616,6 +1616,16 @@ section {
   position: relative;
 }
 
+/* Dot-grid background for content sections */
+#about,
+#projects,
+#blog,
+#contact {
+  background-color: #0a0a0a;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.07) 1px, transparent 1px);
+  background-size: 28px 28px;
+}
+
 .section-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
This commit introduces a subtle dot-grid background pattern to the main content area of the portfolio, starting from the 'About' section onwards.

The pattern is applied to the #about, #projects, #blog, and #contact sections via a new CSS rule in styles.css. This creates a clear visual distinction for the content sections while maintaining a modern, technical aesthetic.