### PR TITLE
feat: Add LinkedIn Post Crafter to mini tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -1118,6 +1118,13 @@
                             </div>
                             <img src="images/image4.png" alt="Django Tutor" class="mini-tool-card-image">
                         </a>
+                        <a href="https://ai.studio/apps/drive/1_j_YElQf7Eei9mv0g-ME0CMU_I4bEVnd" class="mini-tool-card" style="text-decoration:none; color:inherit;">
+                            <div class="mini-tool-card-text">
+                                <h3>LinkedIn Post Crafter</h3>
+                                <p>Craft engaging LinkedIn posts with AI assistance.</p>
+                            </div>
+                            <img src="images/lk.png" alt="LinkedIn Post Crafter" class="mini-tool-card-image">
+                        </a>
                         <!-- Duplicates for animation -->
                         <a href="https://ai.studio/apps/drive/1AdYb41_tW7G_F9RP_VEt_4FnKgmfNJDn" class="mini-tool-card" style="text-decoration:none; color:inherit;">
                             <div class="mini-tool-card-text">
@@ -1146,6 +1153,13 @@
                                 <p>Learn Django with an AI-powered tutor.</p>
                             </div>
                             <img src="images/image4.png" alt="Django Tutor" class="mini-tool-card-image">
+                        </a>
+                        <a href="https://ai.studio/apps/drive/1_j_YElQf7Eei9mv0g-ME0CMU_I4bEVnd" class="mini-tool-card" style="text-decoration:none; color:inherit;">
+                            <div class="mini-tool-card-text">
+                                <h3>LinkedIn Post Crafter</h3>
+                                <p>Craft engaging LinkedIn posts with AI assistance.</p>
+                            </div>
+                            <img src="images/lk.png" alt="LinkedIn Post Crafter" class="mini-tool-card-image">
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
Adds the "LinkedIn Post Crafter" to the "Mini Tools with AI" section on the main page.

Includes the tool's name, a descriptive subtitle, a link to the application, and a placeholder for the `lk.png` image, which will be added separately. The new tool card is duplicated to maintain the existing animation feature.