### PR TITLE
feat: Add POML Architect to mini tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -1282,6 +1282,13 @@
                             </div>
                             <img src="images/pd.png" alt="PodFrame" class="mini-tool-card-image">
                         </a>
+                        <a href="https://poml-architect.vercel.app/" class="mini-tool-card" style="text-decoration:none; color:inherit;">
+                            <div class="mini-tool-card-text">
+                                <h3>POML Architect</h3>
+                                <p>Your Conversational Prompt Engineering Assistant using poml</p>
+                            </div>
+                            <img src="images/poml.png" alt="POML Architect" class="mini-tool-card-image">
+                        </a>
                         <!-- Duplicates for animation -->
                         <a href="https://cleanse-ai.vercel.app/" class="mini-tool-card" style="text-decoration:none; color:inherit;">
                             <div class="mini-tool-card-text">
@@ -1338,6 +1345,13 @@
                                 <p>An AI-powered tool that generates professional podcast scripts</p>
                             </div>
                             <img src="images/pd.png" alt="PodFrame" class="mini-tool-card-image">
+                        </a>
+                        <a href="https://poml-architect.vercel.app/" class="mini-tool-card" style="text-decoration:none; color:inherit;">
+                            <div class="mini-tool-card-text">
+                                <h3>POML Architect</h3>
+                                <p>Your Conversational Prompt Engineering Assistant using poml</p>
+                            </div>
+                            <img src="images/poml.png" alt="POML Architect" class="mini-tool-card-image">
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
Adds the POML Architect tool to the list of mini tools on the main page. This includes adding the tool to both the main list and the duplicated list for the animation.