### PR TITLE
fix: Change CrewAI icon to a letter

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@
 
                     <div class="tool-item">
                         <div class="tool-icon">
-                            <img src="images/crewai.png" alt="CrewAI" style="width: 25px; height: 25px;">
+                            <i class="fas fa-c"></i>
                         </div>
                         <span class="tool-name">CrewAI</span>
                     </div>


### PR DESCRIPTION
Replaced the CrewAI image icon with a simple text-based 'C' icon for better consistency with other tool icons.