### PR TITLE
feat: add StockPicker project to AI section

### DIFF
--- a/index.html
+++ b/index.html
@@ -898,6 +898,47 @@
                         </a>
                     </article>
 
+                    <!-- AI Project: StockPicker -->
+                    <article class="ai-showcase-card fade-in-section">
+                        <a href="https://stockpicker-crew.streamlit.app/" target="_blank"
+                            rel="noopener noreferrer" class="ai-showcase-content"
+                            style="text-decoration:none; color:inherit;">
+                            <div class="ai-showcase-left">
+                                <div class="ai-showcase-header">
+                                    <div class="ai-status-badge active">Live</div>
+                                    <i class="fas fa-arrow-right ai-arrow" aria-hidden="true"></i>
+                                </div>
+                                <h3 class="ai-showcase-title">StockPicker</h3>
+                                <p class="ai-showcase-description">An intelligent platform that leverages CrewAI to analyze market data and provide stock
+recommendations.</p>
+                                <div class="ai-showcase-features">
+                                    <div class="feature-item"><i class="fas fa-check"
+                                            aria-hidden="true"></i><span>stock_picker</span></div>
+                                    <div class="feature-item"><i class="fas fa-check"
+                                            aria-hidden="true"></i><span>financial_researcher</span></div>
+                                    <div class="feature-item"><i class="fas fa-check"
+                                            aria-hidden="true"></i><span>trending_company_finder</span></div>
+                                </div>
+                                <div class="ai-showcase-tech">
+                                    <span class="tech-badge">CrewAI</span>
+                                    <span class="tech-badge">Streamlit</span>
+                                    <span class="tech-badge">Google API</span>
+                                </div>
+
+                            </div>
+                            <div class="ai-showcase-right">
+                                <div class="ai-showcase-preview">
+                                    <div class="preview-header">
+                                        <div class="preview-dots"><span></span><span></span><span></span></div>
+                                        <div class="preview-title">StockPicker Interface</div>
+                                    </div>
+                                    <div class="preview-content"><img src="images/sm.jpg" alt="StockPicker Interface"
+                                            class="preview-image"></div>
+                                </div>
+                            </div>
+                        </a>
+                    </article>
+
                     <!-- AI Project 2: N8N Agents -->
                     <article class="ai-showcase-card fade-in-section">
                         <a href="https://github.com/stars/akshaykarthicks/lists/n8n" target="_blank"


### PR DESCRIPTION
Adds the StockPicker project to the AI projects section of the portfolio.

The new project card includes:
- A link to the live Streamlit application.
- A description of the project.
- Tags for CrewAI, Streamlit, and Google API.
- Key features/agents: stock_picker, financial_researcher, and trending_company_finder.
- The project image `sm.jpg`.

The card is inserted after the "CrewAI Agents" project as requested.